### PR TITLE
Remove log_relation and add object_id rule

### DIFF
--- a/config.c
+++ b/config.c
@@ -73,13 +73,6 @@ int auditLogLevel = LOG;
 bool auditLogParameter = false;
 
 /*
- * Administrators can choose, in SESSION logging, to log each relation involved
- * in READ/WRITE class queries.  By default, SESSION logs include the query but
- * do not have a log entry for each relation.
- */
-bool auditLogRelation = false;
-
-/*
  * Administrators can choose to have the statement run logged only once instead
  * of on every line.  By default, the statement is repeated on every line of
  * the audit log to facilitate searching, but this can cause the log to be

--- a/config.h
+++ b/config.h
@@ -84,7 +84,6 @@ extern bool auditLogCatalog;
 extern char *auditLogLevelString;
 extern int auditLogLevel;
 extern bool auditLogParameter;
-extern bool auditLogRelation;
 extern bool auditLogStatementOnce;
 extern char *auditRole;
 

--- a/rule.c
+++ b/rule.c
@@ -229,11 +229,13 @@ apply_all_rules(AuditEventStackItem *stackItem, ErrorData *edata,
 	bool matched = false;
 
 	char *database_name = NULL;
+	char *object_id = NULL;
 
 	if (stackItem != NULL)
 	{
 		/* XXX : Prepare information for session "statement" logging */
 		database_name = MyProcPort->database_name;
+		object_id = stackItem->auditEvent.objectName;
 	}
 	else
 	{
@@ -259,7 +261,7 @@ apply_all_rules(AuditEventStackItem *stackItem, ErrorData *edata,
 			apply_one_rule(&class, rconf->rules[AUDIT_RULE_CLASS]) &&
 			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_COMMAND_TAG]) &&
 			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_OBJECT_TYPE]) &&
-			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_OBJECT_ID]) &&
+			apply_one_rule(object_id, rconf->rules[AUDIT_RULE_OBJECT_ID]) &&
 			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_APPLICATION_NAME]) &&
 			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_REMOTE_HOST]) &&
 			apply_one_rule(NULL, rconf->rules[AUDIT_RULE_REMOTE_PORT]))


### PR DESCRIPTION
Since we emit the SESSION log with relation name, we no longer need log_relation GUC parameter, so removed it.
Also I added the new rule 'object_id' that is used for filtering using relation name.

Please review it.
