### PR TITLE
Support applying bitmap type rule.

### DIFF
--- a/rule.c
+++ b/rule.c
@@ -389,6 +389,15 @@ apply_timestamp_rule(AuditRule rule)
 static bool
 apply_bitmap_rule(int value, AuditRule rule)
 {
-	/* XXX : we should complete this function */
-	return true;
+	int *bitmap = (int*) rule.values;
+	bool ret = false;
+
+	/* Return true if this rule is not defined */
+	if (rule.values == NULL)
+		return true;
+
+	if (value & *bitmap)
+		ret = true;
+
+	return ret;
 }


### PR DESCRIPTION
Bitmap type rules are class and object_type so far.
Since the class rule has been supported partially, this change also
make class rule available.
