### PR TITLE
add guc(log_connections, log_disconnections, log_replication_commands) check.

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,16 +633,7 @@ Specifies which database elements in the statements will be logged. Possible val
 
  `Session audit logging` logs a log for a SQL (Success or Error) for simple SQL, but sometimes, especially for complex SQL, logs some of logs (for each parts and an Error).
 
-- show command always shows ON
-
- pgaudit has influences to 'show command' for GUC following;
-
- - log_connections
- - log_disconnections
- - log_replication_commands
-
- With pgaudit 'show command' always shows them as ON, even if you set them to OFF and PpstgreSQL does not output the log entries to servelog.
-
+- pgaudit must be set log\_connections, log\_disconnections and log\_replication\_commands is on. If all these parameters are not on, the PostgreSQL server will not start.
 
 ## Authors
 

--- a/conf/postgresql.conf
+++ b/conf/postgresql.conf
@@ -1,2 +1,6 @@
 shared_preload_libraries = 'pgaudit'
 pgaudit.config_file = '../../conf/audit.conf'
+
+log_connections = on
+log_disconnections = on
+log_replication_commands = on

--- a/config.c
+++ b/config.c
@@ -181,7 +181,7 @@ objecttype_to_bitmap(const char *str)
 		object_type = LOG_OBJECT_UNKNOWN;
 	else
 		ereport(ERROR,
-				(errcode(ERRCODE_CONFIG_FILE_ERROR),
+				(errcode(ERRCODE_WRONG_OBJECT_TYPE),
 				 errmsg("invalid value \"%s\" for object_type", str)));
 
 	return object_type;

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1621,8 +1621,8 @@ _PG_init(void)
         ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
                 errmsg("pgaudit must be loaded via shared_preload_libraries")));
 
-	/* 
-	 * pgaudit must be set log_connections, log_disconnections 
+	/*
+	 * pgaudit must be set log_connections, log_disconnections
 	 * and log_replication_commands.
 	 */
     if ( !Log_connections || !Log_disconnections || !log_replication_commands )

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1622,12 +1622,12 @@ _PG_init(void)
                 errmsg("pgaudit must be loaded via shared_preload_libraries")));
 
 	/* 
-	 * If log_connections, log_disconnections, log_replication_commands
-	 * parameter is off, pgaudit is not executed.
+	 * pgaudit must be set log_connections, log_disconnections 
+	 * and log_replication_commands.
 	 */
-	if ( !Log_connections || !Log_disconnections || !log_replication_commands )
-		ereport(ERROR, (
-			errmsg("If log_connections, log_disconnections, log_replication_commands parameter is off, pgaudit is not executed.")));
+    if ( !Log_connections || !Log_disconnections || !log_replication_commands )
+        ereport(ERROR, (
+                errmsg("pgaudit must be set log_connections, log_disconnections and log_replication_commands.")));
 
 		/* Define pgaudit.confg_file */
 	DefineCustomStringVariable(

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -1626,7 +1626,7 @@ _PG_init(void)
 	 * and log_replication_commands.
 	 */
     if ( !Log_connections || !Log_disconnections || !log_replication_commands )
-        ereport(ERROR, (
+        ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
                 errmsg("pgaudit must be set log_connections, log_disconnections and log_replication_commands.")));
 
 		/* Define pgaudit.confg_file */
@@ -1661,7 +1661,8 @@ _PG_init(void)
 
 	/* Parse audit configuration */
 	if (config_file == NULL)
-		ereport(ERROR, (errmsg("\"pgaudit.config_file\" must be specify when pgaudit is loaded")));
+            ereport(ERROR, (errcode(ERRCODE_CONFIG_FILE_ERROR),
+		errmsg("\"pgaudit.config_file\" must be specify when pgaudit is loaded")));
 
 	old_ctx = MemoryContextSwitchTo(TopMemoryContext);
 	ruleConfigs = NULL;

--- a/pgaudit.c
+++ b/pgaudit.c
@@ -42,6 +42,11 @@
 #include "pgaudit.h"
 #include "config.h"
 
+/* for GUC check */
+extern bool Log_connections;
+extern bool Log_disconnections;
+extern bool log_replication_commands;;
+
 PG_MODULE_MAGIC;
 
 void _PG_init(void);
@@ -1615,6 +1620,14 @@ _PG_init(void)
     if (!process_shared_preload_libraries_in_progress)
         ereport(ERROR, (errcode(ERRCODE_OBJECT_NOT_IN_PREREQUISITE_STATE),
                 errmsg("pgaudit must be loaded via shared_preload_libraries")));
+
+	/* 
+	 * If log_connections, log_disconnections, log_replication_commands
+	 * parameter is off, pgaudit is not executed.
+	 */
+	if ( !Log_connections || !Log_disconnections || !log_replication_commands )
+		ereport(ERROR, (
+			errmsg("If log_connections, log_disconnections, log_replication_commands parameter is off, pgaudit is not executed.")));
 
 		/* Define pgaudit.confg_file */
 	DefineCustomStringVariable(

--- a/pgaudit_scan.l
+++ b/pgaudit_scan.l
@@ -183,7 +183,7 @@ void processAuditConfigFile(char* filename)
 	if ((fclose(fp) != 0))
 	{
 		ereport(ERROR,
-				(errcode(ERRCODE_SUCCESSFUL_COMPLETION),
+				(errcode(errcode_for_file_access()),
 				 errmsg("could not close file \"%s\"", filename)));
 	}
 }


### PR DESCRIPTION
pgaudit must be set log_connections, log_disconnections and log_replication_commands is on.
If all these parameters are not on, the PostgreSQL server will not start.